### PR TITLE
First commit (Conformance instead of Numerical Requirement in the Axis Member)

### DIFF
--- a/activity_classes.py
+++ b/activity_classes.py
@@ -65,15 +65,16 @@ def axis_member():
                 "The ensemble member index."),
             ('value', 'float', '0.1',
                 "If parameter varied, value thereof for this member."),
-            ('target_requirement', 'linked_to(designing.numerical_requirement)', '0.1',
-                "URI of the target numerical requirement, if any.")
+            ('conformance', 'activity.conformance', '0.1',
+                "Conformance document for the target requirement that defines this member, if any."),
         ]
     }
 
 
 def conformance():
-    """A specific conformance. Describes how a particular numerical requirement has been implemented.
-    Will normally be linked from an ensemble descriptor.
+    """A specific conformance. Describes how a particular numerical
+    requirement has been implemented.  Will normally be linked from an
+    ensemble descriptor.
 
     """
     return {

--- a/activity_classes.py
+++ b/activity_classes.py
@@ -65,7 +65,7 @@ def axis_member():
                 "The ensemble member index."),
             ('value', 'float', '0.1',
                 "If parameter varied, value thereof for this member."),
-            ('conformance', 'activity.conformance', '0.1',
+            ('conformance', 'linked_to(activity.conformance)', '0.1',
                 "Conformance document for the target requirement that defines this member, if any."),
         ]
     }


### PR DESCRIPTION
This change replaces in the axis_member class the numerical requirement property with a conformance property. 

The reason is that we need to store both, but the conformance document already contains the numerical requirement. This is also consistent with, e.g., the ensemble class, which stores conformances but not (directly) requirements.    