### PR TITLE
Adding explicit version control to the CIM2 respository.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -22,15 +22,14 @@ from . import software_enums
 from . import time as time_classes
 
 
-
 # Ontology name.
 NAME = 'cim'
 
 # Ontology version.
-VERSION = '2'
+VERSION = '2.0.36'
 
 # Ontology doc string.
-DOC = 'Metafor CIM ontology schema - version 2'
+DOC = 'ESDOC CIM ontology schema - version 2'
 
 
 def activity():
@@ -99,7 +98,7 @@ def shared():
 
 
 def software():
-    """Types that describe the software that constiutes a climate model.
+    """Types that describe the software that constitutes a climate model.
 
     """
     return {
@@ -108,7 +107,7 @@ def software():
     }
 
 def time():
-    """Types that describe the software that constiutes a climate model.
+    """Types that describe the software that constitutes a climate model.
 
     """
     return {


### PR DESCRIPTION
So that it will now return version in the 2.X.Y format required
by the contributing guidelines.