### PR TITLE
deleted axis_member from designing_classes.py

### DIFF
--- a/designing_classes.py
+++ b/designing_classes.py
@@ -7,19 +7,6 @@
 """
 
 
-def axis_member():
-    """PLACEHOLDER for the real axis_member.
-
-    """
-    return {
-        'type': 'class',
-        'base': None,
-        'is_abstract': False,
-        'properties': [
-        ]
-    }
-
-
 def domain_requirements():
     """Properties of the domain which needs to be simulated, extent and/or resolution.
 


### PR DESCRIPTION
This was a legacy place-holder - non longer needed.