### PR TITLE
Performance descriptions: add missing definition, fix typo

### DIFF
--- a/platform_classes.py
+++ b/platform_classes.py
@@ -208,7 +208,7 @@ def performance_detail():
             ('coupling_cost', 'float', '0.1',
              'Coupling cost measures the overhead caused by coupling. This can include the cost of the coupling algorithm itself (which may involve grid interpolation and computation of transfer coefficients for conservative coupling) as well as load imbalance. It is the normalized difference between the time-processor integral for the whole model versus the sum of individual concurrent components.'),
             ('memory_bloat', 'float', '0.1',
-             'Memory bloat is the ratio of the actual memory size to the ideal memory size (the size of the complete model state, which in theory is all you need to hold in memory)Mi, defined below.'),
+             'Memory bloat is the ratio of the actual memory size, defined as M − NP × X where M is the measured runtime memory usage and X the size of the executable files, to the ideal memory size Mi, the size of the complete model state, which in theory is all you need to hold in memory.'),
             ('data_output_cost', 'float', '0.1',
              'Data output cost is the cost of performing I/O, and is the ratio of CHSY with and without I/O.'),
             ('data_intensity', 'float', '0.1',

--- a/platform_classes.py
+++ b/platform_classes.py
@@ -4,8 +4,7 @@
 .. module:: platform_classes.py
    :synopsis: Set of CIM v2 ontology type definitions.
    applying to the description of computers and the
-   performance of code running on those computers. of
-
+   performance of code running on those computers.
 """
 
 
@@ -167,9 +166,9 @@ def performance():
             ('model', 'linked_to(science.model)', '1.1',
                 "Model for which performance was tested."),
             ('resolution', 'int', '0.1',
-                 'Resolution measured as the number of gridpoints (or more generally, spatial degrees of freedom) NX x NY x NZ per component with an independent discretization'),
+                 'Resolution measured as the number of gridpoints (or more generally, spatial degrees of freedom) NX x NY x NZ per component with an independent discretization.'),
             ('complexity', 'int', '0.1',
-                 'Complexity measured as the number of prognostic variables per component with an independent discretization'),
+                 'Complexity measured as the number of prognostic variables per component with an independent discretization.'),
             ('platform', 'linked_to(platform.machine)', '1.1',
                  'Platform on which performance was tested.'),
             ('compiler', 'str', '0.1',
@@ -177,18 +176,18 @@ def performance():
 
             # CPMIP computational cost
             ('simulated_years_per_day', 'float', '0.1',
-                 'Simulated years per day (SYPD) in a 24h period on the given platform'),
+                 'Simulated years per day (SYPD) in a 24h period on the given platform.'),
             ('actual_simulated_years_per_day', 'float', '0.1',
                  'Actual simulated years per day (ASYPD) in a 24h period on the given platform obtained from a typical long-running simulation with the model. Inclusive of system interruptions, queue wait time, or issues with the model workflow, etc.'),
             ('core_hours_per_simulated_year', 'float', '0.1',
                  'Core-hours per simulated year (CHSY). This is measured as the product of the model runtime for 1 SY, and the numbers of cores allocated. Note that if allocations are done on a node basis then all cores on a node are charged against the allocation, regardless of whether or not they are used.'),
             ('joules_per_simulated_year', 'float', '0.1',
-                 'The energy cost of a simulation, measured in joules per simulated year (JPSY). Given the energy E in joules consumed over a budgeting interval T (generally 1 month or 1 year, in units of hours), JPSY=CHSY*E*T/NP'),
+                 'The energy cost of a simulation, measured in joules per simulated year (JPSY). Given the energy E in joules consumed over a budgeting interval T (generally 1 month or 1 year, in units of hours), JPSY=CHSY*E*T/NP.'),
             ('parallelisation', 'float', '0.1',
-             'Total number of cores (NP) allocated for the run, regardless of whether or or all cores were used all of the time.'),
+             'Total number of cores (NP) allocated for the run, regardless of whether or not all cores were used all of the time.'),
 
             ('further_detail', 'platform.performance_detail', '0.1',
-                'Set of additional information related to coupling, memory and I/O'),
+                'Set of additional information related to coupling, memory and I/O.'),
 
             # Subcomponent performance
             ('subcomponent_performance', 'linked_to(platform.performance)', '0.N',
@@ -207,13 +206,13 @@ def performance_detail():
         'properties': [
             # CPMIP coupling, memory, I/O
             ('coupling_cost', 'float', '0.1',
-             'Coupling cost measures the overhead caused by coupling. This can include the cost of the coupling algorithm itself (which may involve grid interpolation and computation of transfer coefficients for conservative coupling) as well as load imbalance. It is the normalized difference between the time-processor integral for the whole model versus the sum of individual concurrent components'),
+             'Coupling cost measures the overhead caused by coupling. This can include the cost of the coupling algorithm itself (which may involve grid interpolation and computation of transfer coefficients for conservative coupling) as well as load imbalance. It is the normalized difference between the time-processor integral for the whole model versus the sum of individual concurrent components.'),
             ('memory_bloat', 'float', '0.1',
              'Memory bloat is the ratio of the actual memory size to the ideal memory size (the size of the complete model state, which in theory is all you need to hold in memory)Mi, defined below.'),
             ('data_output_cost', 'float', '0.1',
              'Data output cost is the cost of performing I/O, and is the ratio of CHSY with and without I/O.'),
             ('data_intensity', 'float', '0.1',
-             'Data intensity the amount of data produced per compute-hour, in units GB per compute-hour.'),
+             'Data intensity is the amount of data produced per compute-hour, in units GB per compute-hour.'),
             ]
     }
 


### PR DESCRIPTION
Whilst double-checking the clarity of the performance spreadsheet (PR to go up shortly) I noticed a few minor aspects that should be fixed in the CIM v2.2, namely:

* use of the phrase "defined below" in the description for the `"memory_bloat"` property of the 'platform detail' class, where the definition was only provided subsequently in the paper and not in these standalone summary descriptions; and
* a typo in the description of the `"parallelisation"` property.

So this PR makes minor changes to lift the relevant definition from the CPMIP paper into the `"memory_bloat"` description so it makes sufficient sense in itself and fixes the typo. (I've also taken the liberty of adding full-stops at the end of any description without them in the performance-related classes because I think it helps to indicate the end point where descriptions are long.)

Though these are non-controversial and fairly trivial changes, since I don't have responsibility for the CIM itself I reckon I should get confirmation that these changes are OK, hence the review request. The main aspect to check is that the `"memory_bloat"` description makes sense without having to refer to the details in the CPMIP paper metric definition enrty. Thanks.